### PR TITLE
Fixed compile with ASM using Visual C++ greater than 6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 project(Engoo)
 
+if( COMMAND cmake_policy )
+	if( POLICY CMP0054 )
+		cmake_policy( SET CMP0054 NEW )
+	endif( POLICY CMP0054 )
+endif( COMMAND cmake_policy )
+
 if( MSVC )
 	# Statically link the run time and disable run time checks in debug mode.
 	string(REPLACE "/MD " " " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE} )
@@ -29,7 +35,7 @@ if( MSVC )
 endif( MSVC )
 
 # On for now until the ASM is made to work on newer compilers
-option( NO_ASM "Disable assembly code" ON )
+option( NO_ASM "Disable assembly code" OFF )
 
 if( NOT NO_ASM )
 	if( MSVC )

--- a/WinQuake/sys_win.c
+++ b/WinQuake/sys_win.c
@@ -278,7 +278,7 @@ void Sys_MakeCodeWriteable (unsigned long startaddr, unsigned long length)
 {
 	DWORD  flOldProtect;
 
-	if (!VirtualProtect((LPVOID)startaddr, length, PAGE_READWRITE, &flOldProtect))
+	if (!VirtualProtect((LPVOID)startaddr, length, PAGE_EXECUTE_READWRITE, &flOldProtect))
    		Sys_Error("Protection change failed\n");
 }
 


### PR DESCRIPTION
I was sent a copy of Visual C++ 6.0 Standard and found that the CMake project works perfectly there.  In fact compared to the hand built project, the CMake project generates faster binaries.  (Not as fast as yours, but I suspect you're using Professional which has more optimization options.)

With that in mind, I found what was causing the ASM to crash on VC++ 2005.  The change compiles fine for me on VC++ 6.0, but if it doesn't for you, then I'm sure you can add an ifdef and define the constant to the old value.

With this Engoo compiles and runs when compiled with VC++ 2005 and 2015 with ASM enabled.  Binaries made with these compilers seem to be slightly faster, but I haven't done a scientific test.
